### PR TITLE
fix: recreate proxy during production rollout

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -295,6 +295,9 @@ run_rollout() {
 
   log "Building and starting production Compose stack"
   docker compose --profile production up -d --build
+
+  log "Recreating Caddy proxy to remount the current Caddyfile"
+  docker compose --profile production up -d --no-deps --force-recreate proxy
 }
 
 wait_for_url() {

--- a/server/deployment-security.test.ts
+++ b/server/deployment-security.test.ts
@@ -99,6 +99,7 @@ describe("production deploy script", () => {
     expect(deployScript).toContain("docker compose --profile production");
     expect(deployScript).toContain("docker compose --profile production config --quiet");
     expect(deployScript).toContain("docker compose --profile production up -d --build");
+    expect(deployScript).toContain("docker compose --profile production up -d --no-deps --force-recreate proxy");
     expect(deployScript).toContain("/api/health");
   });
 });


### PR DESCRIPTION
## Summary
- force-recreate the Caddy proxy during production rollout so file bind mounts pick up the current Caddyfile after git pull
- extend the deployment security test to lock this behavior

## Validation
- pnpm run test:server -- deployment-security.test.ts
- bash -n deploy.sh
- docker compose --profile production config --quiet

## Deployment note
- The VPS proxy was manually recreated once after discovering the bind-mounted Caddyfile inode issue; this PR makes future rollouts do that automatically.